### PR TITLE
Primitive FontFeature Implementation

### DIFF
--- a/managed/NativeSkia/Text/SkFontFeature.cs
+++ b/managed/NativeSkia/Text/SkFontFeature.cs
@@ -1,0 +1,20 @@
+﻿using System.Runtime.InteropServices;
+
+namespace QuestPDF.Skia.Text;
+
+internal sealed class SkFontFeature
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct FontFeature
+    {
+        public int Tag; // Encoded as 32-bit integer
+        public int Value;
+    }
+
+    public static IntPtr StructToIntPtr(FontFeature feature)
+    {
+        IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(FontFeature)));
+        Marshal.StructureToPtr(feature, ptr, false);
+        return ptr;
+    }
+}

--- a/managed/NativeSkia/Text/SkTextStyle.cs
+++ b/managed/NativeSkia/Text/SkTextStyle.cs
@@ -25,6 +25,9 @@ internal struct TextStyleConfiguration
     public float LetterSpacing;
     public float WordSpacing;
     public float BaselineOffset;
+
+    public const int FONT_FEATURES_LENGTH = 16;
+    [MarshalAs(UnmanagedType.ByValArray, SizeConst = FONT_FEATURES_LENGTH)] public IntPtr[] FontFeatures;
     
     public enum FontWeights
     {

--- a/native/src/text/textStyle.cpp
+++ b/native/src/text/textStyle.cpp
@@ -4,6 +4,11 @@
 
 extern "C" {
 
+struct FontFeature {
+    int tag;
+    int value;
+};
+
 struct TextStyleConfiguration {
     static const int FONT_FAMILIES_LENGTH = 16;
 
@@ -26,6 +31,9 @@ struct TextStyleConfiguration {
     SkScalar letterSpacing;
     SkScalar wordSpacing;
     SkScalar baselineOffset;
+
+    static const int FONT_FEATURES_LENGTH = 16;
+    FontFeature* fontFeatures[FONT_FEATURES_LENGTH];
 };
 
 QUEST_API skia::textlayout::TextStyle *text_style_create(TextStyleConfiguration configuration) {
@@ -48,6 +56,22 @@ QUEST_API skia::textlayout::TextStyle *text_style_create(TextStyleConfiguration 
 
     textStyle->setFontFamilies(fontFamilies);
     // end
+
+    for (auto & fontFeature : configuration.fontFeatures) {
+        if(fontFeature == nullptr)
+            continue;
+
+        if(fontFeature->tag == 0)
+            continue;
+
+        char decodedTag[4];
+        decodedTag[0] = (fontFeature->tag >> 24) & 0xFF;
+        decodedTag[1] = (fontFeature->tag >> 16) & 0xFF;
+        decodedTag[2] = (fontFeature->tag >> 8) & 0xFF;
+        decodedTag[3] = fontFeature->tag & 0xFF;
+
+        textStyle->addFontFeature(SkString(decodedTag), fontFeature->value);
+    }
 
     if (configuration.foregroundColor != 0) {
         SkPaint paint;


### PR DESCRIPTION
A primitive implementation to see whether font features could work. Skia already offers the support for font features so essentially it is all about passing the values to the skia library.
I've not that much information on font features yet, but as far as I know it is always a 4-character wide string describing some functionality (https://en.wikipedia.org/wiki/List_of_typographic_features). 

For the test to pass, Calibri.ttf has to be added to the input files. I did not include it because i wasn't sure about the license model. Also the test will always pass as there is no deticated check. 