### PR TITLE
Fix crash for macos-il2cpp-unity configuration

### DIFF
--- a/managed/NativeSkia/Text/SkParagraph.cs
+++ b/managed/NativeSkia/Text/SkParagraph.cs
@@ -20,9 +20,9 @@ internal sealed class SkParagraph : IDisposable
     public SkSize[] GetLineMetrics()
     {
         API.paragraph_get_line_metrics(Instance, out var array, out var arrayLength);
-        
+
         var managedArray = new SkSize[arrayLength];
-        
+
         var size = Marshal.SizeOf<SkSize>();
         
         for (var i = 0; i < arrayLength; i++)
@@ -31,7 +31,8 @@ internal sealed class SkParagraph : IDisposable
             managedArray[i] = Marshal.PtrToStructure<SkSize>(ptr);
         }
 
-        Marshal.FreeHGlobal(array);
+        API.paragraph_delete_line_metrics(array);
+
         return managedArray;
     }
     
@@ -41,8 +42,8 @@ internal sealed class SkParagraph : IDisposable
         
         var managedArray = new int[arrayLength];
         Marshal.Copy(array, managedArray,  0, arrayLength);
-        Marshal.FreeHGlobal(array);
-        
+        API.paragraph_delete_unresolved_codepoints(array);
+
         return managedArray;
     }
     
@@ -60,7 +61,7 @@ internal sealed class SkParagraph : IDisposable
             managedArray[i] = Marshal.PtrToStructure<SkRect>(ptr);
         }
 
-        Marshal.FreeHGlobal(array);
+        API.paragraph_delete_positions(array);
         return managedArray;
     }
     
@@ -78,7 +79,7 @@ internal sealed class SkParagraph : IDisposable
             managedArray[i] = Marshal.PtrToStructure<SkRect>(ptr);
         }
 
-        Marshal.FreeHGlobal(array);
+        API.paragraph_delete_positions(array);
         return managedArray;
     }
     
@@ -115,5 +116,14 @@ internal sealed class SkParagraph : IDisposable
         
         [DllImport(SkiaAPI.LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern void paragraph_delete(IntPtr paragraph);
+
+        [DllImport(SkiaAPI.LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void paragraph_delete_line_metrics(IntPtr array);
+
+        [DllImport(SkiaAPI.LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void paragraph_delete_unresolved_codepoints(IntPtr array);
+
+        [DllImport(SkiaAPI.LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void paragraph_delete_positions(IntPtr array);
     }
 }

--- a/native/src/text/paragraph.cpp
+++ b/native/src/text/paragraph.cpp
@@ -23,6 +23,10 @@ QUEST_API void paragraph_get_line_metrics(skia::textlayout::Paragraph *paragraph
     }
 }
 
+QUEST_API void paragraph_delete_line_metrics(SkSize *array) {
+    delete[] array;
+}
+
 QUEST_API void paragraph_get_unresolved_codepoints(skia::textlayout::Paragraph *paragraph, SkUnichar **outputArray, int *outputArrayLength) {
     const auto codepoints = paragraph->unresolvedCodepoints();
 
@@ -35,6 +39,10 @@ QUEST_API void paragraph_get_unresolved_codepoints(skia::textlayout::Paragraph *
         (*outputArray)[index++] = codepoint;
 }
 
+QUEST_API void paragraph_delete_unresolved_codepoints(SkUnichar *array) {
+    delete[] array;
+}
+
 QUEST_API void paragraph_get_placeholder_positions(skia::textlayout::Paragraph *paragraph, SkRect **outputArray, int *outputArrayLength) {
     const auto placeholders = paragraph->getRectsForPlaceholders();
 
@@ -43,6 +51,10 @@ QUEST_API void paragraph_get_placeholder_positions(skia::textlayout::Paragraph *
 
     for (int i = 0; i < *outputArrayLength; ++i)
         (*outputArray)[i] = placeholders[i].rect;
+}
+
+QUEST_API void paragraph_delete_positions(SkRect *array) {
+    delete[] array;
 }
 
 QUEST_API void paragraph_get_text_range_positions(skia::textlayout::Paragraph *paragraph, int rangeStart, int rangeEnd, SkRect **outputArray, int *outputArrayLength) {


### PR DESCRIPTION
Fixes #3 

Fix Unity build crash on macOS/Linux. The root cause is how the `new` and `delete` operators are overridden on macOS/Linux, which leads to a “pointer being freed was not allocated” error. 

When you allocate the memory with the `new `operator, the resource is always supposed to be released with `delete`.

The crash happens in the `SkParagraph.cs` class when it tries to free memory using `Marshal.FreeHGlobal()`—which under the hood maps to the C `free()` function. If the memory layout used by `new[]` differs from that used by `malloc`, calling `free()` directly can corrupt the heap and trigger this error.

Solution for this is to add new functions which expose `delete` operator for managed code.

Below is an example of the code Unity uses to override `new` and `delete` operators. It shows exactly how Unity allocates extra metadata before the returned pointer and then subtracts it back off when deleting, explaining why a plain `free()` call on the shifted pointer will fail:

```C++
#include<iostream>
#include<stdlib.h>
 
using namespace std;

void * operator new(size_t size)
{
    void * p = malloc(size + sizeof(int));
    int *ip = reinterpret_cast<int *>(p);
    ip[0] = 15;
    cout << "Created array with " << ip[0] << " flag" << endl;
    return ip + 1;
}
 
void operator delete(void * p)
{
    int *ip = reinterpret_cast<int *>(p);
    cout << "Delete array with " << *(ip - 1) << " flag" << endl;
    free(ip - 1);
}
 
int main()
{
    int n = 5, i;
    float * p = new float[n];
    delete [] p;

    // But if you call free here as Marshal.FreeHGlobal would do
    // There will be an exception
    // free(p);
}
```